### PR TITLE
utilites update

### DIFF
--- a/docs/operations/summary-files.md
+++ b/docs/operations/summary-files.md
@@ -16,67 +16,32 @@ The job output will have messages added to show that this was specified. Note th
 
 :::tip Example 
 
+```
 RSJ Version=15.00.000
-
 exe path=/ops/bin/RSJ15.00/RSJ=
-
 argv[0]=/ops/bin/RSJ15.00.00/RSJ=
-
 argv[1]=SYM000=
-
 argv[2]=GOODNIGHT=
-
 argv[3]=-s/SYM/SYM000/summaryconfig=
-
 INFO Wed Mar 25 11:12:21 2015 Copyright@ SMA 2015=
-
-INFO Wed Mar 25 11:12:21 2015 This code may not be transferred/lent/copied
-
-outside your organization without SMA approval=
-
-INFO Wed Mar 25 11:12:21 2015 Summary Configuration file is =/SYM/SYM000/
-
-LETTERSPECS/GoodnightSummaryConfig=
-
+INFO Wed Mar 25 11:12:21 2015 This code may not be transferred/lent/copied outside your organization without SMA approval=
+INFO Wed Mar 25 11:12:21 2015 Summary Configuration file is =/SYM/SYM000/LETTERSPECS/GoodnightSummaryConfig=
 INFO Wed Mar 25 11:12:21 2015 SYM=SYM000=
-
 INFO Wed Mar 25 11:12:21 2015 Jobfile=GOODNIGHT=
-
 INFO Wed Mar 25 11:12:21 2015 Restart Point was not input=
-
 INFO Wed Mar 25 11:12:22 2015 default_file=/SYM/SYM000/BATCH/SMA_DEFAULTS=
-
 ....
-
 %BATCHRETURNCODE: 000 Job successful from Program: BATCHHOSTCONTROL.
-
 %COMPLETIONDATETIME 03/25/15 11:14:44
-
-======================= COMPLETION OF BATCH PROCESSING
-
-======================
-
+======================= COMPLETION OF BATCH PROCESSING ======================
 INFO Wed Mar 25 11:14:45 2015 Closed jobfile ONLINE=
-
 INFO Wed Mar 25 11:14:45 2015 Closed jobfile GOODNIGHT=
-
-INFO Wed Mar 25 11:14:46 2015 SummaryFileName =[/SYM/SYM000/LETTERSPECS/
-
-GoodnightSummary]=
-
-INFO Wed Mar 25 11:14:46 2015 opcon_message using environment this_path=/usr/
-
-local/lsam-05.20.30/bin=
-
-INFO Wed Mar 25 11:14:46 2015 opcon_message using path=/usr/local/lsam-
-
-05.20.30/bin/sma_status=
-
-INFO Wed Mar 25 11:14:46 2015 opcon_message= /usr/local/lsam-05.20.30/bin/
-
-sma_status "Waiting for LockFile"=
-
+INFO Wed Mar 25 11:14:46 2015 SummaryFileName =[/SYM/SYM000/LETTERSPECS/GoodnightSummary]=
+INFO Wed Mar 25 11:14:46 2015 opcon_message using environment this_path=/usr/local/lsam-05.20.30/bin=
+INFO Wed Mar 25 11:14:46 2015 opcon_message using path=/usr/local/lsam-05.20.30/bin/sma_status=
+INFO Wed Mar 25 11:14:46 2015 opcon_message= /usr/local/lsam-05.20.30/bin/sma_status "Waiting for LockFile"=
 INFO Wed Mar 25 11:14:46 2015 all done=
+```
 
 ::: 
 

--- a/docs/operations/symitar-job-file-commands.md
+++ b/docs/operations/symitar-job-file-commands.md
@@ -1,5 +1,45 @@
 # Symitar Job File Commands
 
+## SMA_DEFAULTS
+
+The file SMA_DEFAULTS is stored in /SYM/SYMnnn/BATCH. It is a completely optional file. If the file is present, RSJ will read this file before it starts processing on the users job file. Users can place SMA Technologies' directives in it to customize error handling. The directives that can be placed in the file are:
+
+* ;EXCEPTION_REPORT
+
+* ;EXCEPTION_REPORT
+
+* ;EXCEPTION_REPORT
+
+* ;EXCEPTION_REPORT_CLEAR
+
+* ;ERROR_LEVEL
+
+* ;MAX_EXCEPTIONS
+
+* ;DIE_NO_ERROR_CODE
+
+* ;FATAL_MESSAGE
+
+* ;FATAL_MESSAGE_CLEAR
+
+* ;CREATE_OPCON_REPORTS_LINKS
+
+* ;FAIL_ON_PERSISTENT_EDITFILE
+
+* ;JAVA_HOME
+
+* ;MINUTES_TO_WAIT_FOR_EDITFILE
+
+* ;SEND_OUTPUT_TO_QOUT
+
+If any other commands or comments are found in this file they will be ignored.
+
+:::warning 
+
+This file will be read and executed for all job files to be run. Make sure that reasonable/wanted values are set for error processing. To override these defaults for a single job, you will need to place the desired error processing commands at the start of the job file.
+
+:::
+
 ## CREATE_OPCON_REPORTS_LINKS
 
 CREATE_OPCON_REPORTS_LINKS can be set in the SMA_DEFAULTS file (or set in any batch file - like the other RSJ directives to selectively turn on and off link creation). The default value is "true."
@@ -387,43 +427,3 @@ The directive FATAL_MESSAGE_CLEAR removes all fatal error messages (including th
 Usage:
 
 ```;FATAL_MESSAGE_CLEAR```
-
-## SMA_DEFAULTS
-
-The file SMA_DEFAULTS is stored in /SYM/SYMnnn/BATCH. It is a completely optional file. If the file is present, RSJ will read this file before it starts processing on the users job file. Users can place SMA Technologies' directives in it to customize error handling. The directives that can be placed in the file are:
-
-;EXCEPTION_REPORT
-
-* ;EXCEPTION_REPORT
-
-* ;EXCEPTION_REPORT
-
-* ;EXCEPTION_REPORT_CLEAR
-
-* ;ERROR_LEVEL
-
-* ;MAX_EXCEPTIONS
-
-* ;DIE_NO_ERROR_CODE
-
-* ;FATAL_MESSAGE
-
-* ;FATAL_MESSAGE_CLEAR
-
-* ;CREATE_OPCON_REPORTS_LINKS
-
-* ;FAIL_ON_PERSISTENT_EDITFILE
-
-* ;JAVA_HOME
-
-* ;MINUTES_TO_WAIT_FOR_EDITFILE
-
-* ;SEND_OUTPUT_TO_QOUT
-
-If any other commands or comments are found in this file they will be ignored.
-
-:::warning 
-
-This file will be read and executed for all job files to be run. Make sure that reasonable/wanted values are set for error processing. To override these defaults for a single job, you will need to place the desired error processing commands at the start of the job file.
-
-:::

--- a/docs/rsj-utility-programs.md
+++ b/docs/rsj-utility-programs.md
@@ -685,7 +685,7 @@ Possible SMADump_scf errors are:
 
 /ops/bin/SMADump_scf -f/SYM/SYM000/BATCH/CC.LATE.FEE
 
-::::
+:::
 
 ## sma_hostinfo
 


### PR DESCRIPTION
1 corrected some formatting in Utilities section so that translate2commas is not embedded in a note.
2 moved information about SMA_DEFAULTS to the top of that section.
3 removed some line returns in a job output example as to make more like live output file.